### PR TITLE
Alternative fix for RT#86592

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,6 +10,7 @@ WriteMakefile(
    MIN_PERL_VERSION => 5.006,
    PREREQ_PM => {
        Symbol => 0,
+       'Scalr::Util' => 0,
    },
    META_MERGE => {
        resources => {
@@ -21,6 +22,7 @@ WriteMakefile(
    },
    BUILD_REQUIRES => {
        Test => 0,
+       B    => 0,
    },
 );
 

--- a/lib/Data/Dump.pm
+++ b/lib/Data/Dump.pm
@@ -12,6 +12,7 @@ require Exporter;
 $VERSION = "1.22";
 $DEBUG = 0;
 
+use Scalar::Util qw/looks_like_number/;
 use overload ();
 use vars qw(%seen %refcnt @dump @fixup %require $TRY_BASE64 @FILTERS $INDENT);
 
@@ -229,7 +230,7 @@ sub _dump
 	    if (!defined $$rval) {
 		$out = "undef";
 	    }
-	    elsif (do {no warnings 'numeric'; $$rval + 0 eq $$rval}) {
+	    elsif (looks_like_number($$rval) && $$rval + 0 eq $$rval) {
 		$out = $$rval;
 	    }
 	    else {

--- a/t/sv-flags.t
+++ b/t/sv-flags.t
@@ -1,0 +1,14 @@
+use strict;
+
+use Test qw(plan ok);
+
+plan tests => 2;
+
+use B;
+use Data::Dump qw(dump);
+
+my $c = "abc";
+my $orig_flags = B::svref_2object(\$c)->FLAGS;
+ok(dump($c), qq("abc"));
+ok B::svref_2object(\$c)->FLAGS, $orig_flags;
+


### PR DESCRIPTION
Here is alternative fix for RT#86592, which uses Scalar::Util looks_like_number to do not change the output.

B is still used for tests.
