### PR TITLE
feature request. skip codepoint of utf8 in quote()

### DIFF
--- a/lib/Data/Dump.pm
+++ b/lib/Data/Dump.pm
@@ -13,10 +13,11 @@ $VERSION = "1.22";
 $DEBUG = 0;
 
 use overload ();
-use vars qw(%seen %refcnt @dump @fixup %require $TRY_BASE64 @FILTERS $INDENT);
+use vars qw(%seen %refcnt @dump @fixup %require $TRY_BASE64 @FILTERS $INDENT $DO_NOT_CODEPOINT_OF_UTF8);
 
 $TRY_BASE64 = 50 unless defined $TRY_BASE64;
 $INDENT = "  " unless defined $INDENT;
+$DO_NOT_CODEPOINT_TO_UTF8 = 0;
 
 sub dump
 {
@@ -544,7 +545,7 @@ sub quote {
   s/([\0-\037])(?!\d)/sprintf('\\%o',ord($1))/eg;
 
   s/([\0-\037\177-\377])/sprintf('\\x%02X',ord($1))/eg;
-  s/([^\040-\176])/sprintf('\\x{%X}',ord($1))/eg;
+  s/([^\040-\176])/sprintf('\\x{%X}',ord($1))/eg unless $Data::Dump::DO_NOT_CODEPOINT_OF_UTF8;
 
   return qq("$_");
 }


### PR DESCRIPTION
Hello.

I think to try a little better output of DBIx::Class::Schema::Loader.

It is used in the schema loader Data::Dump::dump() is.
https://github.com/dbsrgits/dbix-class-schema-loader/blob/master/lib/DBIx/Class/Schema/Loader/Base.pm#L2868

.pm file to be output contains the "use utf8" but, Perl Unicode strings would have been CODEPOINT of, it is ugly.

<pre>
# lib/MyApp/Schema/Result/Lang.pm
__PACKAGE__->add_columns(
  "lang",
  {
    data_type => "enum",
    extra => {
      custom_type_name => "lang_type",
      list => [
        [
          "\x{82F1}\x{8A9E}",
          "\x{65E5}\x{672C}\x{8A9E}",
          "\x{4E2D}\x{56FD}\x{8A9E}",
        ]
      ],
    },
    is_nullable => 1,
  },
</pre>


Apply this patch, and $DO_NOT_CODEPOINT_TO_UTF8 =1. It is clean as this.

<pre>
--- a/lib/MyApp/Schema/Result/Lang.pm
+++ b/lib/MyApp/Schema/Result/Lang.pm
@@ -23,11 +23,7 @@ __PACKAGE__->add_columns(
     data_type => "enum",
     extra => {
       custom_type_name => "lang_type",
-      list => [
-        "\x{82F1}\x{8A9E}",
-        "\x{65E5}\x{672C}\x{8A9E}",
-        "\x{4E2D}\x{56FD}\x{8A9E}",
-      ],
+      list => ["英語", "日本語", "中国語"],
     },
     is_nullable => 1,
   },
</pre>


I think it is good this flag was in the Data::Dump.
Could you please merge.

Cheers,
Tomohiro Hosaka
