### PR TITLE
Fix warning about negative repetition on bleadperl

### DIFF
--- a/lib/Data/Dump.pm
+++ b/lib/Data/Dump.pm
@@ -358,7 +358,8 @@ sub _dump
 	    my $vpad = $INDENT . (" " x ($klen_pad ? $klen_pad + 4 : 0));
 	    $val =~ s/\n/\n$vpad/gm;
 	    my $kpad = $nl ? $INDENT : " ";
-	    $key .= " " x ($klen_pad - length($key)) if $nl;
+	    $key .= " " x ($klen_pad - length($key))
+		if $nl and $klen_pad > length($key);
 	    $out .= "$kpad$key => $val,$nl";
 	}
 	$out =~ s/,$/ / unless $nl;


### PR DESCRIPTION
Data::Dump itself doesn't use warnings, but under `-w` (e.g. `Test::Harness` or `prove -w`), this can trigger anyway.

This warning breaks the `DBIx::Class::Schema::Loader` bleadperl/devcpan CI build, which runs with `prove -w`.