### PR TITLE
Deal with blessed regexes

### DIFF
--- a/lib/Data/Dump.pm
+++ b/lib/Data/Dump.pm
@@ -191,7 +191,7 @@ sub _dump
     }
     elsif ($type eq "SCALAR" || $type eq "REF" || $type eq "REGEXP") {
 	if ($ref) {
-	    if ($class && $class eq "Regexp") {
+            if ($type eq "REGEXP") {
 		my $v = "$rval";
 
 		my $mod = "";
@@ -218,7 +218,7 @@ sub _dump
 		$v =~ s/\Q$sep\E/\\$sep/g;
 
 		$out = "qr$sep$v$sep$mod";
-		undef($class);
+		undef($class) if $class && $class eq "Regexp";
 	    }
 	    else {
 		delete $seen{$id} if $type eq "SCALAR";  # will be seen again shortly

--- a/t/regexp.t
+++ b/t/regexp.t
@@ -19,6 +19,7 @@ $a = {
    h => qr*/|,:*,
    i => qr*/|,:#*,
    j => bless(qr/Foo/, "Regexp::Alt"),
+   k => \qr/Foo/,
 };
 
 ok(Data::Dump::dump($a) . "\n", <<'EOT');
@@ -36,5 +37,6 @@ ok(Data::Dump::dump($a) . "\n", <<'EOT');
   h => qr#/|,:#,
   i => qr/\/|,:#/,
   j => bless(qr/Foo/, "Regexp::Alt"),
+  k => \qr/Foo/,
 }
 EOT

--- a/t/regexp.t
+++ b/t/regexp.t
@@ -18,6 +18,7 @@ $a = {
    g => qr,///////,,
    h => qr*/|,:*,
    i => qr*/|,:#*,
+   j => bless(qr/Foo/, "Regexp::Alt"),
 };
 
 ok(Data::Dump::dump($a) . "\n", <<'EOT');
@@ -34,5 +35,6 @@ ok(Data::Dump::dump($a) . "\n", <<'EOT');
   g => qr|///////|,
   h => qr#/|,:#,
   i => qr/\/|,:#/,
+  j => bless(qr/Foo/, "Regexp::Alt"),
 }
 EOT


### PR DESCRIPTION
Regex objects (like qr/Foo/) are kind of special in Perl
because they have a REGEXP reftype but are blessed into "Regexp"
package. That means it is not desirable to dump qr/Foo/ into

```
bless(qr/Foo/, "Regexp")
```

which is redudant, but if the blessed package is other than "Regexp"
it is necessary to resort to the "bless" expression, as in

```
bless(qr/Foo/, "Regexp::Alt")
```

Previous to this change, this was the output by Data::Dump for such cases:

```
perl -MData::Dump=pp -e 'pp(bless qr/Foo/, "Regexp::Alt")'
do {
  my $a = bless(do{\(my $o = do{my $fix})}, "Regexp::Alt");
  $$a = $a;
  $a;
}
```

From this change on, the output becomes

```
perl -MData::Dump=pp -e 'pp(bless qr/Foo/, "Regexp::Alt")'
bless(qr/Foo/, "Regexp::Alt")
```

which evaluates correctly and that follows what Data::Dumper 
and Data::Dump::Streamer do.
