### PR TITLE
Let user set wrap size with $Data::Dump::WRAP

### DIFF
--- a/lib/Data/Dump.pm
+++ b/lib/Data/Dump.pm
@@ -9,14 +9,15 @@ require Exporter;
 @EXPORT = qw(dd ddx);
 @EXPORT_OK = qw(dump pp dumpf quote);
 
-$VERSION = "1.23";
+$VERSION = "1.23mcm";
 $DEBUG = 0;
 
 use overload ();
-use vars qw(%seen %refcnt @dump @fixup %require $TRY_BASE64 @FILTERS $INDENT);
+use vars qw(%seen %refcnt @dump @fixup %require $TRY_BASE64 @FILTERS $INDENT $WRAP);
 
 $TRY_BASE64 = 50 unless defined $TRY_BASE64;
 $INDENT = "  " unless defined $INDENT;
+$WRAP = 60 unless defined $WRAP;
 
 sub dump
 {
@@ -229,9 +230,6 @@ sub _dump
 	    if (!defined $$rval) {
 		$out = "undef";
 	    }
-	    elsif ($$rval =~ /^-?(?:nan|inf)/i) {
-		$out = str($$rval);
-	    }
 	    elsif (do {no warnings 'numeric'; $$rval + 0 eq $$rval}) {
 		$out = $$rval;
 	    }
@@ -329,7 +327,7 @@ sub _dump
 	my $nl = "";
 	my $klen_pad = 0;
 	my $tmp = "@keys @vals";
-	if (length($tmp) > 60 || $tmp =~ /\n/ || $tied) {
+	if (length($tmp) > $WRAP || $tmp =~ /\n/ || $tied) {
 	    $nl = "\n";
 
 	    # Determine what padding to add


### PR DESCRIPTION
A trivial patch to let the user change the size an object may grow to before it gets wrapped.  I left the default at 60 from your code, but changed it to an exposed variable $Data::Dump::WRAP where the user can set a larger size if desired.

If you're interested in it, you can take it as it is, or I can write some tests and/or documentation if you'd prefer.

I don't check my EMail often so if there's something you'd like done post-haste, ping me on PerlMonks, which I visit nearly every day.

Thanks!